### PR TITLE
catch missing do() at the end of subcommands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/xdotoolify.js
+++ b/src/xdotoolify.js
@@ -204,7 +204,7 @@ _Xdotoolify.prototype.sleep = function(ms) {
 };
 _Xdotoolify.prototype.run = function(f, ...rest) {
   this._addOperation({
-    type: 'runOrCheck',
+    type: 'run',
     func: f,
     args: rest,
   });
@@ -212,7 +212,7 @@ _Xdotoolify.prototype.run = function(f, ...rest) {
 };
 _Xdotoolify.prototype.check = function(f, ...rest) {
   this._addOperation({
-    type: 'runOrCheck',
+    type: 'check',
     func: f,
     args: rest.slice(0, rest.length - 1),
     callback: rest[rest.length - 1],
@@ -221,7 +221,7 @@ _Xdotoolify.prototype.check = function(f, ...rest) {
 };
 _Xdotoolify.prototype.checkUntil = function(f, ...rest) {
   this._addOperation({
-    type: 'runOrCheck',
+    type: 'check',
     func: f,
     args: rest.slice(0, rest.length - 2),
     callback: rest[rest.length - 2],
@@ -352,7 +352,7 @@ _Xdotoolify.prototype.do = async function() {
           await this._do(commandArr.join(' '));
           commandArr = [];
           await _sleep(op.ms);
-        } else if (op.type === 'runOrCheck') {
+        } else if (['run', 'check'].includes(op.type)) {
           await this._do(commandArr.join(' '));
           commandArr = [];
           if (op.func._xdotoolifyWithPage === undefined) {
@@ -431,8 +431,16 @@ _Xdotoolify.prototype.do = async function() {
               }
               await _sleep(100);
             }
+            if (op.type === 'run' && this.operations.length > 0) {
+              throw new Error('You forgot to add ".do() "' +
+                'at the end of a subcommand.')
+            }
           } else {
             await run(false);
+            if (op.type === 'run' && this.operations.length > 0) {
+              throw new Error('You forgot to add ".do() "' +
+                'at the end of a subcommand.')
+            }
           }
         } else if (op.type === 'mousemove') {
           await this._do(commandArr.join(' '));

--- a/test/xdotoolify-spec.js
+++ b/test/xdotoolify-spec.js
@@ -162,4 +162,38 @@ describe('xdotoolify', function() {
 
     expect(errorMsg).toContain('Most recent value: TypeError: Converting circular structure to JSON');
   }));
+
+  it('should throw error when missing do() at the end of run command', syncify(async function() {
+    let errorMsg = 'Nothing thrown';
+    let goodFunc = Xdotoolify.setupWithPage((page) => { return 5; });
+    const withDo = Xdotoolify.setupWithPage((page) => {
+      return page.X
+          .checkUntil(goodFunc, x => x * 2, 10)
+          .do();
+    });
+    const withoutDo = Xdotoolify.setupWithPage((page) => {
+      return page.X
+          .checkUntil(goodFunc, x => x * 2, 10);
+    });
+
+    try {
+      await page.X
+          .run(withDo)
+          .checkUntil(goodFunc, x => x * 2, 10).do();
+    } catch (e) {
+      errorMsg = e.message;
+    }
+
+    expect(errorMsg).toBe('Nothing thrown');
+
+    try {
+      await page.X
+          .run(withoutDo)
+          .checkUntil(goodFunc, x => x * 2, 10).do();
+    } catch (e) {
+      errorMsg = e.message;
+    }
+    
+    expect(errorMsg).toBe('You forgot to add ".do() "at the end of a subcommand.');
+  }));
 });


### PR DESCRIPTION
Added code to throw an error if there are operations left after running a `run` command. Also added test to verify behaviour.