### PR TITLE
Added checkUntil requirement after interaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.27",
+  "version": "1.0.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "xdotoolify simulates clicks and keystrokes in selenium in a way that is indistinguishable from a real user's actions",
   "main": "dist/xdotoolify.js",
   "scripts": {

--- a/test/xdotoolify-spec.js
+++ b/test/xdotoolify-spec.js
@@ -196,4 +196,74 @@ describe('xdotoolify', function() {
     
     expect(errorMsg).toBe('You forgot to add ".do() "at the end of a subcommand.');
   }));
+
+  it('should throw error when missing checkUntil after interaction', syncify(async function() {
+    let errorMsg = 'Nothing thrown';
+    let goodFunc = Xdotoolify.setupWithPage((page) => { return 5; });
+    let withCheck = Xdotoolify.setupWithPage((page) => {
+      return page.X
+          .click()
+          .checkUntil(goodFunc, x => x * 2, 10)
+          .do()
+    });
+
+    try {
+      await page.X
+          .run(withCheck)
+          .do()
+    } catch (e) {
+      errorMsg = e.message;
+    }
+
+    expect(errorMsg).toBe('Nothing thrown');
+
+    withCheck = Xdotoolify.setupWithPage((page) => {
+      return page.X
+          .click()
+          .checkNothing()
+          .do()
+    });
+
+    try {
+      await page.X
+          .run(withCheck)
+          .do()
+    } catch (e) {
+      errorMsg = e.message;
+    }
+
+    expect(errorMsg).toBe('Nothing thrown');
+
+    let withoutCheck = Xdotoolify.setupWithPage((page) => {
+      return page.X
+          .click()
+          .do({unsafe: true});
+    });
+
+    try {
+      await page.X
+          .run(withoutCheck)
+          .do()
+    } catch (e) {
+      errorMsg = e.message;
+    }
+    
+    expect(errorMsg).toBe('Unsafe do() calls are not allowed within safe ones.');
+
+    withoutCheck = Xdotoolify.setupWithPage((page) => {
+      return page.X
+          .click()
+          .do();
+    });
+
+    try {
+      await page.X
+          .run(withoutCheck)
+          .do()
+    } catch (e) {
+      errorMsg = e.message;
+    }
+    
+    expect(errorMsg).toBe('Missing checkUntil after interaction.');
+  }));
 });


### PR DESCRIPTION
Added a check after every interaction (click, button press, etc.) for a checkUntil. This check can be skipped by running in a few ways:
- running the interaction with checkAfter == false,
- running do() with option.unsafe == true
- running checkNothing right after interaction

If these conditions are not met, and an interaction is not followed by a checkUntil, an error is thrown.