### PR TITLE
Bug fix: nested and sibling statements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "description": "xdotoolify simulates clicks and keystrokes in selenium in a way that is indistinguishable from a real user's actions",
   "main": "dist/xdotoolify.js",
   "scripts": {


### PR DESCRIPTION
There was a bug in which only the first .do() statement to run would set the unsafe property. Because of this, subsequent unsafe do() calls would fail even on the same recursion level. Added code so that the value for unsafe is set at the highest recursion level for every do() function. A second bug is also fixed, in which it was previously allowed to have chains such as `unsafe > safe > unsafe`. Now, `unsafe` statements are not allowed anywhere under a `safe` ones, even if the outermost statement is an `unsafe` one.