### PR TITLE
Deprecated "check" actions

### DIFF
--- a/src/xdotoolify.js
+++ b/src/xdotoolify.js
@@ -213,7 +213,7 @@ _Xdotoolify.prototype.run = function(f, ...rest) {
 };
 _Xdotoolify.prototype.check = function(f, ...rest) {
   this._addOperation({
-    type: 'check',
+    type: 'deprecatedCheck',
     func: f,
     args: rest.slice(0, rest.length - 1),
     callback: rest[rest.length - 1],
@@ -522,12 +522,20 @@ _Xdotoolify.prototype.do = async function(options = {unsafe: false}) {
     this.operations = [];
     for (var i = 0; i < operations.length; ++i) {
       var op = operations[i];
+
+      if (!options.unsafe && op.type === 'deprecatedCheck') {
+        throw new Error(
+          '\'check\' actions are now deprecated. Please rewrite' +
+          ' as \'checkUntil\'.'
+        )
+      }
+
       try {
         if (op.type === 'sleep') {
           await this._do(commandArr.join(' '));
           commandArr = [];
           await _sleep(op.ms);
-        } else if (['run', 'check'].includes(op.type)) {
+        } else if (['run', 'check', 'deprecatedCheck'].includes(op.type)) {
           await this._do(commandArr.join(' '));
           commandArr = [];
           if (op.func._xdotoolifyWithPage === undefined) {

--- a/test/xdotoolify-spec.js
+++ b/test/xdotoolify-spec.js
@@ -17,7 +17,7 @@ describe('xdotoolify', function() {
     let badFunc = () => {};
 
     try {
-      await page.X.check(badFunc, noop).do();
+      await page.X.check(badFunc, noop).do({unsafe: true});
     } catch (e) {
       errorMsg = e.message;
     }
@@ -30,7 +30,9 @@ describe('xdotoolify', function() {
     let goodFunc = Xdotoolify.setupWithPage((page) => {});
 
     try {
-      await page.X.check(goodFunc, () => { throw new Error('inside'); }).do();
+      await page.X.check(goodFunc, () => { throw new Error('inside'); }).do({
+        unsafe: true
+      });
     } catch (e) {
       errorMsg = e.message;
     }
@@ -44,7 +46,9 @@ describe('xdotoolify', function() {
     let goodFunc = Xdotoolify.setupWithPage((page) => { return [{a: 5}, 6]; });
 
     try {
-      await page.X.check(goodFunc, () => { throw new Error('inside'); }).do();
+      await page.X.check(goodFunc, () => { throw new Error('inside'); }).do({
+        unsafe: true
+      });
     } catch (e) {
       errorMsg = e.message;
       stack = e.stack;
@@ -64,7 +68,7 @@ describe('xdotoolify', function() {
     try {
       await page.X.check(badFunc, () => {
         throw new Error('callback');
-      }).do();
+      }).do({unsafe: true});
     } catch (e) {
       stack = e.stack;
     }
@@ -352,5 +356,34 @@ describe('xdotoolify', function() {
     }
 
     expect(errorMsg).toBe('Missing checkUntil after interaction.');
+  }));
+
+  it('should not allow check statements in safe do call', syncify(async function() {
+    let errorMsg = 'Nothing thrown';
+    let goodFunc = Xdotoolify.setupWithPage((page) => { return 5; });
+    const noop = () => {};
+
+    try {
+      await page.X
+          .check(goodFunc, noop)
+          .do({unsafe: true});
+    } catch (e) {
+      errorMsg = e.message;
+    }
+
+    expect(errorMsg).toBe('Nothing thrown');
+
+    try {
+      await page.X
+          .check(goodFunc, noop)
+          .do();
+    } catch (e) {
+      errorMsg = e.message;
+    }
+
+    expect(errorMsg).toBe(
+      '\'check\' actions are now deprecated. Please rewrite' +
+      ' as \'checkUntil\'.'
+    );
   }));
 });


### PR DESCRIPTION
Deprecating 'check' actions so that they throw an error when run within a safe `do` statement. Added tests and modified old related ones.