### PR TITLE
Allow same mouse position in auto functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "description": "xdotoolify simulates clicks and keystrokes in selenium in a way that is indistinguishable from a real user's actions",
   "main": "dist/xdotoolify.js",
   "scripts": {


### PR DESCRIPTION
I made changes to allow for mousemove to be run with the same position, and made it the default option for `auto` functions (e.g. `autoClick`, `autoKey`).