### PR TITLE
Added check after clicks to ensure they click the correct element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.36",
+  "version": "1.0.37",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.36",
+  "version": "1.0.37",
   "description": "xdotoolify simulates clicks and keystrokes in selenium in a way that is indistinguishable from a real user's actions",
   "main": "dist/xdotoolify.js",
   "scripts": {


### PR DESCRIPTION
1) Added a check until every click of types 1, 2, and 3 to ensure that a) the click event is registered before continuing and b) the clicked element is either a descendant of or the exact element given by the selector.
2) Added a check inside `_getElementAndBrowserRect` to ensure the element given by the selector is not in a different frame or a frame itself.