### PR TITLE
Ignore coordinate seletors during click verification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "description": "xdotoolify simulates clicks and keystrokes in selenium in a way that is indistinguishable from a real user's actions",
   "main": "dist/xdotoolify.js",
   "scripts": {

--- a/src/xdotoolify.js
+++ b/src/xdotoolify.js
@@ -934,7 +934,11 @@ _Xdotoolify.prototype.do = async function(options = {unsafe: false}) {
           this.page.xjsLastPos.x = pos.x;
           this.page.xjsLastPos.y = pos.y;
         } else if (op.type === 'click') {
-          if(op.mouseButton in [1, 2, 3] && op.selector) {
+          if (
+            op.mouseButton in [1, 2, 3] &&
+            op.selector && 
+            (Array.isArray(op.selector) || typeof op.selector === 'string')
+            ) {
             await _addClickHandler(this.page, op.selector, 'click');
             commandArr.push(`click ${op.mouseButton}`);
             await this._do(commandArr.join(' '));


### PR DESCRIPTION
There was a previous issue where using coordinate selectors or relative position ones would lead to an error during verification, as it would try to find an element using the selector. Fixed this issue.