### PR TITLE
Returning after waitForClickAction promise resolved

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "description": "xdotoolify simulates clicks and keystrokes in selenium in a way that is indistinguishable from a real user's actions",
   "main": "dist/xdotoolify.js",
   "scripts": {

--- a/src/xdotoolify.js
+++ b/src/xdotoolify.js
@@ -20,9 +20,11 @@ const _waitForClickAction = async function(page, timeout) {
     }
     if (!clickInfo || clickInfo.registered) {
       resolve(null);
+      return;
     }
     if (clickInfo.error) {
       resolve(clickInfo.error);
+      return;
     }
     resolve('Timed out while waiting for click to be registered.');
   })


### PR DESCRIPTION
Promise would go past resolve statements and fail sometimes. Fixed by returning right after resolve.