### PR TITLE
Clearing command array before adding click listener

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "description": "xdotoolify simulates clicks and keystrokes in selenium in a way that is indistinguishable from a real user's actions",
   "main": "dist/xdotoolify.js",
   "scripts": {

--- a/src/xdotoolify.js
+++ b/src/xdotoolify.js
@@ -944,6 +944,11 @@ _Xdotoolify.prototype.do = async function(options = {unsafe: false}) {
             op.selector && 
             (Array.isArray(op.selector) || typeof op.selector === 'string')
           ) {
+            // clean up previous commands
+            await this._do(commandArr.join(' '));
+            await _sleep(50);
+            commandArr = [];
+
             try {
               await _addClickHandler(this.page, op.selector, 'click');
             } catch (e) {
@@ -970,6 +975,11 @@ _Xdotoolify.prototype.do = async function(options = {unsafe: false}) {
             op.selector &&
             (Array.isArray(op.selector) || typeof op.selector === 'string')
           ) {
+            // clean up previous commands
+            await this._do(commandArr.join(' '));
+            await _sleep(50);
+            commandArr = [];
+
             try {
               await _addClickHandler(this.page, op.selector, 'mousedown');
             } catch (e) {


### PR DESCRIPTION
Cleaning up command array before adding click listener. This is done to avoid removing the listener on the wrong kind of events.