### PR TITLE
addRequireCheckImmediatelyAfter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "description": "xdotoolify simulates clicks and keystrokes in selenium in a way that is indistinguishable from a real user's actions",
   "main": "dist/xdotoolify.js",
   "scripts": {

--- a/test/xdotoolify-spec.js
+++ b/test/xdotoolify-spec.js
@@ -386,4 +386,56 @@ describe('xdotoolify', function() {
       ' as \'checkUntil\'.'
     );
   }));
+
+  it('should require check after addRequireCheckImmediatelyAfter', syncify(async function() {
+    let errorMsg = 'Nothing thrown';
+    let goodFunc = Xdotoolify.setupWithPage((page) => { return 5; });
+    let fnWithRequire = Xdotoolify.setupWithPage(
+      async (page) => {
+        await page.X
+            .addRequireCheckImmediatelyAfter().do();
+      }
+    );
+    const noop = () => {};
+
+    try {
+      await page.X
+          .run(goodFunc)
+          .do();
+    } catch (e) {
+      errorMsg = e.message;
+    }
+
+    expect(errorMsg).toBe('Nothing thrown');
+
+    try {
+      await page.X
+          .run(goodFunc)
+          .run(fnWithRequire)
+          .do();
+    } catch (e) {
+      errorMsg = e.message;
+    }
+
+    expect(errorMsg).toBe(
+      'Missing checkUntil after running ' +
+      '\'requireCheckImmediatelyAfter\'.'
+    );
+
+    errorMsg = null;
+
+    try {
+      await page.X
+          .run(goodFunc)
+          .addRequireCheckImmediatelyAfter()
+          .do();
+    } catch (e) {
+      errorMsg = e.message;
+    }
+
+    expect(errorMsg).toBe(
+      'Missing checkUntil after running ' +
+      '\'requireCheckImmediatelyAfter\'.'
+    );
+  }));
 });


### PR DESCRIPTION
I added a `addRequireCheckImmediatelyAfter` function which can be added to custom functions to enforce checking after they are run. I also noticed some bugs. For example old line 974 had `if (op.mouseButton in [1, 2, 3] ...)`. I was thinking of `in` as in Python, where it checks that the given object is an element of the array, but it actually takes `op.mouseButton` as an index and checks if it exists in the array. For almost every case, this would have worked (since 1 is an index in the array), but this could have led to future problems.