### PR TITLE
Replaced "prepublish" with "prepare"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "description": "xdotoolify simulates clicks and keystrokes in selenium in a way that is indistinguishable from a real user's actions",
   "main": "dist/xdotoolify.js",
   "scripts": {
     "build": "babel src --out-dir dist",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "test": "babel-node test.js"
   },
   "repository": {


### PR DESCRIPTION
It seems the `prepublish` script in `package.json` is deprecated ([see here](https://docs.npmjs.com/cli/v8/using-npm/scripts)). I replaced it with `prepare`.