### PR TITLE
Accept function as argument + save values for later use

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "description": "xdotoolify simulates clicks and keystrokes in selenium in a way that is indistinguishable from a real user's actions",
   "main": "dist/xdotoolify.js",
   "scripts": {


### PR DESCRIPTION
Added `Xdotoolify.arg`, which wraps a function which can then be used as an argument for other Xdotoolify functions. Also added `_Xdoolify.saveValue` and `Xdotoolify.getSavedValue`, which can be used to save variables for later use. Also added tests for this, and expanded coverage for `addRequireCheckImmediatelyAfter`.