### PR TITLE
Fixed click verification bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.52",
+  "version": "1.0.53",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.52",
+  "version": "1.0.53",
   "description": "xdotoolify simulates clicks and keystrokes in selenium in a way that is indistinguishable from a real user's actions",
   "main": "dist/xdotoolify.js",
   "scripts": {

--- a/src/xdotoolify.js
+++ b/src/xdotoolify.js
@@ -19,15 +19,22 @@ const _waitForClickAction = async function(page, timeout) {
       if (!clickInfo || clickInfo.registered) { break; }
       await _sleep(50);
     }
-    if (!clickInfo || (clickInfo.registered && !clickInfo.error)) {
+    if (!clickInfo) {
       resolve(null);
       return;
-    } else {
-      resolve(clickInfo.error);
+    }
+    if (!clickInfo.registered) {
+      reject(new Error(
+        'Timed out while waiting for click to be registered.'
+      ));
       return;
     }
-    resolve('Timed out while waiting for click to be registered.');
-  })
+    if (clickInfo.error) {
+      reject(new Error(clickInfo.error));
+      return;
+    }
+    resolve(null);
+  });
 };
 
 var _addClickHandler = async function(page, selector, eventType) {
@@ -1068,14 +1075,7 @@ _Xdotoolify.prototype.do = async function(
             }
             commandArr.push(`click ${op.mouseButton}`);
             await this._do(commandArr.join(' '));
-            try {
-              const clickError = await _waitForClickAction(this.page, Xdotoolify.defaultCheckUntilTimeout);
-              if (clickError) {
-                throw new Error(clickError);
-              }
-            } catch (e) {
-              throw new Error(e);
-            }
+            await _waitForClickAction(this.page, Xdotoolify.defaultCheckUntilTimeout);
             await _sleep(50);
             commandArr = [];
           } else {
@@ -1099,14 +1099,7 @@ _Xdotoolify.prototype.do = async function(
             }
             commandArr.push(`mousedown ${op.mouseButton}`);
             await this._do(commandArr.join(' '));
-            try {
-              const clickError = await _waitForClickAction(this.page, Xdotoolify.defaultCheckUntilTimeout);
-              if (clickError) {
-                throw new Error(clickError);
-              }
-            } catch (e) {
-              throw new Error(e);
-            }
+            await _waitForClickAction(this.page, Xdotoolify.defaultCheckUntilTimeout);
             await _sleep(50);
             commandArr = [];
           } else {


### PR DESCRIPTION
There was an bug in which `_waitForClickAction` would fail to return an error message in the case in which a click was not registered. It would instead return `window.clickInfo.error`, whose default value is `null`, which would be counted as a passing case.