### PR TITLE
Raise warning instead of failure when click check fails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.55",
+  "version": "1.0.56",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "xdotoolify",
-      "version": "1.0.55",
+      "version": "1.0.56",
       "license": "MIT",
       "devDependencies": {
         "fast-deep-equal": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.55",
+  "version": "1.0.56",
   "description": "xdotoolify simulates clicks and keystrokes in selenium in a way that is indistinguishable from a real user's actions",
   "main": "dist/xdotoolify.js",
   "scripts": {

--- a/src/xdotoolify.js
+++ b/src/xdotoolify.js
@@ -1085,7 +1085,19 @@ _Xdotoolify.prototype.do = async function(
             }
             commandArr.push(`click ${op.mouseButton}`);
             await this._do(commandArr.join(' '));
-            await _waitForClickAction(this.page, Xdotoolify.defaultCheckUntilTimeout);
+            try {
+              // TO DO: It seems that Firefox sometimes swallows clicks
+              // when passing from one textarea to another. This needs
+              // to be investigated. For now, it suffices to alert
+              // in the case of these "missed clicks" in case that
+              // they correspond to actual failures.
+              await _waitForClickAction(this.page, Xdotoolify.defaultCheckUntilTimeout);
+            } catch (e) {
+              console.warn(
+                'Click was not registered. Not necessarily a failure ' +
+                'unless it is accompanied by one.'
+              );
+            }
             await _sleep(50);
             commandArr = [];
           } else {
@@ -1109,7 +1121,14 @@ _Xdotoolify.prototype.do = async function(
             }
             commandArr.push(`mousedown ${op.mouseButton}`);
             await this._do(commandArr.join(' '));
-            await _waitForClickAction(this.page, Xdotoolify.defaultCheckUntilTimeout);
+            try {
+              await _waitForClickAction(this.page, Xdotoolify.defaultCheckUntilTimeout);
+            } catch (e) {
+              console.warn(
+                'Click was not registered. Not necessarily a failure ' +
+                'unless it is accompanied by one.'
+              );
+            }
             await _sleep(50);
             commandArr = [];
           } else {


### PR DESCRIPTION
The click event listener sometimes fails to register clicks when switching from one textarea to another one. This is not normally accompanied by a failure, so a warning is raised instead of throwing an error.