### PR TITLE
Fixed bug where misclicks were caught and wrong warning was printed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.56",
+  "version": "1.0.57",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "xdotoolify",
-      "version": "1.0.56",
+      "version": "1.0.57",
       "license": "MIT",
       "devDependencies": {
         "fast-deep-equal": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.56",
+  "version": "1.0.57",
   "description": "xdotoolify simulates clicks and keystrokes in selenium in a way that is indistinguishable from a real user's actions",
   "main": "dist/xdotoolify.js",
   "scripts": {

--- a/src/xdotoolify.js
+++ b/src/xdotoolify.js
@@ -24,13 +24,17 @@ const _waitForClickAction = async function(page, timeout) {
       return;
     }
     if (!clickInfo.registered) {
-      reject(new Error(
-        'Timed out while waiting for click to be registered.'
-      ));
+      reject(new Error({
+        message: 'Timed out while waiting for click to be registered.',
+        errorCode: 'click.timeOut'
+      }));
       return;
     }
     if (clickInfo.error) {
-      reject(new Error(clickInfo.error));
+      reject(new Error({
+        message: clickInfo.error,
+        errorCode: 'click.wrongElement'
+      }));
       return;
     }
     resolve(null);
@@ -1093,10 +1097,14 @@ _Xdotoolify.prototype.do = async function(
               // they correspond to actual failures.
               await _waitForClickAction(this.page, Xdotoolify.defaultCheckUntilTimeout);
             } catch (e) {
-              console.warn(
-                'Click was not registered. Not necessarily a failure ' +
-                'unless it is accompanied by one.'
-              );
+              if (e.errorCode === 'click.timeOut') {
+                console.warn(
+                  'Click was not registered. Not necessarily a failure ' +
+                  'unless it is accompanied by one.'
+                );
+              } else {
+                throw e;
+              }
             }
             await _sleep(50);
             commandArr = [];
@@ -1124,10 +1132,14 @@ _Xdotoolify.prototype.do = async function(
             try {
               await _waitForClickAction(this.page, Xdotoolify.defaultCheckUntilTimeout);
             } catch (e) {
-              console.warn(
-                'Click was not registered. Not necessarily a failure ' +
-                'unless it is accompanied by one.'
-              );
+              if (e.errorCode === 'click.timeOut') {
+                console.warn(
+                  'Click was not registered. Not necessarily a failure ' +
+                  'unless it is accompanied by one.'
+                );
+              } else {
+                throw e;
+              }
             }
             await _sleep(50);
             commandArr = [];


### PR DESCRIPTION
On the last update I made changes so that 'timed out' clicks that would raise a warning instead of throwing an error. However, the catch block also caught clicks that _were_ registered on the wrong element, leading to the wrong message being printed. This PR fixes this issue.