### PR TITLE
Fixed bug where misclicks were caught and wrong warning was printed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "xdotoolify",
-      "version": "1.0.57",
+      "version": "1.0.58",
       "license": "MIT",
       "devDependencies": {
         "fast-deep-equal": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "description": "xdotoolify simulates clicks and keystrokes in selenium in a way that is indistinguishable from a real user's actions",
   "main": "dist/xdotoolify.js",
   "scripts": {

--- a/src/xdotoolify.js
+++ b/src/xdotoolify.js
@@ -24,17 +24,19 @@ const _waitForClickAction = async function(page, timeout) {
       return;
     }
     if (!clickInfo.registered) {
-      reject(new Error({
-        message: 'Timed out while waiting for click to be registered.',
-        errorCode: 'click.timeOut'
-      }));
+      const error = new Error(
+        'Timed out while waiting for click to be registered.'
+      );
+      error.errorCode = 'click.timeOut';
+      reject(error);
       return;
     }
     if (clickInfo.error) {
-      reject(new Error({
-        message: clickInfo.error,
-        errorCode: 'click.wrongElement'
-      }));
+      const error = new Error(
+        'Timed out while waiting for click to be registered.'
+      );
+      error.errorCode = 'click.wrongElement';
+      reject(error);
       return;
     }
     resolve(null);


### PR DESCRIPTION
Error message was being printed as `Error: [object Object]`. Fixed this.