### PR TITLE
Fixed "getElementVisibleBoundingRect" for fixed elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.58",
+  "version": "1.0.59",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.58",
+  "version": "1.0.59",
   "description": "xdotoolify simulates clicks and keystrokes in selenium in a way that is indistinguishable from a real user's actions",
   "main": "dist/xdotoolify.js",
   "scripts": {

--- a/src/xdotoolify.js
+++ b/src/xdotoolify.js
@@ -163,6 +163,9 @@ var _getElementAndBrowserRect = async function(page, selector) {
         element = element.parentElement;
         var style = window.getComputedStyle(element);
         var overflow = style.overflow + style.overflowX + style.overflowY;
+        if (style.position === 'fixed') {
+          break;
+        }
         if (/auto|scroll|hidden/.test(overflow)) {
           rect = intersectRects(rect, element.getBoundingClientRect());
           if (!rect) {


### PR DESCRIPTION
There was an issue when getting the visible bounding rect for fixed elements. The function kept looping through the parents to find one with `auto`, `scroll`, or `hidden` values in its overflow style, continuously checking that the element was not hidden due to this. This breaks with `fixed` elements, though, since they exist outside the normal flow. The function was changed so that it breaks when it encounters a `fixed` element, instead of continuing to inspect its parents.