### PR TITLE
Catching "NoSuchWindowError" when tabs are closed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.62",
+  "version": "1.0.63",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.62",
+  "version": "1.0.63",
   "description": "xdotoolify simulates clicks and keystrokes in selenium in a way that is indistinguishable from a real user's actions",
   "main": "dist/xdotoolify.js",
   "scripts": {

--- a/src/xdotoolify.js
+++ b/src/xdotoolify.js
@@ -14,9 +14,21 @@ const _waitForDOM = async function(page, timeout) {
 
   return new Promise(async (resolve, reject) => {
     const i = setInterval(async () => {
-      const readyState = await page.executeScript(function() {
-        return document.readyState;
-      });
+      let readyState;
+
+      try {
+        readyState = await page.executeScript(function() {
+          return document.readyState;
+        });
+      } catch (e) {
+        // this error is thrown when a tab is closed
+        // so we ignore it
+        if (e.name === 'NoSuchWindowError') {
+          resolve();
+        } else {
+          throw e;
+        }
+      }
 
       if (readyState === 'complete') {
         clearInterval(i);


### PR DESCRIPTION
There was an error caused by the last update when tabs were closed. Catching that error and ignoring it.