### PR TITLE
waitForDOM was taking longer than it should because it was only run i…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.63",
+  "version": "1.0.64",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdotoolify",
-  "version": "1.0.63",
+  "version": "1.0.64",
   "description": "xdotoolify simulates clicks and keystrokes in selenium in a way that is indistinguishable from a real user's actions",
   "main": "dist/xdotoolify.js",
   "scripts": {


### PR DESCRIPTION
…n the interval. Basically, the run time for tests increased very significantly because it would wait an initial 100ms before running `waitForDOM` for the first time. Fixed.